### PR TITLE
[IMP] prevent using addresses that could cause error 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ addon | version | maintainers | summary
 [website_sale_country_select2](website_sale_country_select2/) | 17.0.1.0.0 |  | Changes country in customer address form to be select2
 [website_sale_create_user](website_sale_create_user/) | 17.0.1.0.1 |  | Website sale create user
 [website_sale_default_country](website_sale_default_country/) | 17.0.1.0.0 |  | Website Sale Default Country
-[website_sale_default_invoice_address](website_sale_default_invoice_address/) | 17.0.1.0.0 |  | Use predefined invoice address from partner, if set
+[website_sale_default_invoice_address](website_sale_default_invoice_address/) | 17.0.1.1.0 |  | Use predefined invoice address from partner, if set
 [website_sale_default_privacies](website_sale_default_privacies/) | 17.0.1.0.0 |  | Website sale default privacy values
 [website_sale_disable_pricelist_selector](website_sale_disable_pricelist_selector/) | 17.0.1.0.0 |  | If a pricelist is assigned to a partner, hide pricelist selector in shop
 [website_sale_disable_qty_in_cart](website_sale_disable_qty_in_cart/) | 17.0.1.0.0 |  | Helper module to disable changing product quantity in cart

--- a/website_sale_default_invoice_address/README.rst
+++ b/website_sale_default_invoice_address/README.rst
@@ -8,6 +8,8 @@ eCommerce: Partner Default Invoice Address
 
 * Extend the functionality of partner_default_invoice_address to 
   suggest the default invoice address for eCommerce orders
+* Adds a domain limitation to the possible addresses, to avoid
+  error 403 in address step of checkout
 
 Configuration
 =============

--- a/website_sale_default_invoice_address/__manifest__.py
+++ b/website_sale_default_invoice_address/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "eCommerce: Partner Default Invoice Address",
     "summary": "Use predefined invoice address from partner, if set",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "category": "Website",
     "website": "https://gitlab.com/tawasta/odoo/e-commerce",
     "author": "Tawasta",

--- a/website_sale_default_invoice_address/models/__init__.py
+++ b/website_sale_default_invoice_address/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_partner
 from . import website

--- a/website_sale_default_invoice_address/models/res_partner.py
+++ b/website_sale_default_invoice_address/models/res_partner.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    # prevent selecting invoice addresses that would raise
+    # error 403 in website_sale's address()
+    default_partner_invoice_id = fields.Many2one(
+        domain="[('id', 'child_of', commercial_partner_id)]"
+    )

--- a/website_sale_default_invoice_address/models/website.py
+++ b/website_sale_default_invoice_address/models/website.py
@@ -11,16 +11,35 @@ class Website(models.Model):
     def _prepare_sale_order_values(self, partner_sudo):
         self.ensure_one()
 
-        _logger.info("_prepare_sale_order_values reached")
+        partner_obj = self.env["res.partner"]
+
         values = super()._prepare_sale_order_values(partner_sudo)
+
+        invoice_address_to_use = False
 
         if partner_sudo.default_partner_invoice_id:
             # Check if partner has a default invoice address
-            values["partner_invoice_id"] = partner_sudo.default_partner_invoice_id.id
+            invoice_address_to_use = partner_sudo.default_partner_invoice_id.id
         elif partner_sudo.commercial_partner_id.default_partner_invoice_id:
             # Check if commercial partner has a default invoice address
-            values[
-                "partner_invoice_id"
-            ] = partner_sudo.commercial_partner_id.default_partner_invoice_id.id
+            invoice_address_to_use = (
+                partner_sudo.commercial_partner_id.default_partner_invoice_id.id
+            )
+
+        # Do a check to prevent using invoice addresses that would raise
+        # error 403 in website_sale's address()
+        if invoice_address_to_use:
+            allowed_invoice_addresses = partner_obj.search(
+                [("id", "child_of", partner_sudo.commercial_partner_id.ids)]
+            )
+
+            if invoice_address_to_use in [a.id for a in allowed_invoice_addresses]:
+                values["partner_invoice_id"] = invoice_address_to_use
+            else:
+                _logger.debug(
+                    "Skipped using invoice address id %s, partner %s "
+                    "did not have access to it "
+                    % (invoice_address_to_use, partner_sudo.id)
+                )
 
         return values


### PR DESCRIPTION
- limit default invoice addresses only to those that are related to the partner's commercial partner. Others could cause an access error in checkout's address() step