### PR TITLE
[FIX] add t-nocache attribute to is_public_user() check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ addon | version | maintainers | summary
 [website_sale_extra_step_settings](website_sale_extra_step_settings/) | 17.0.1.0.0 |  | Allow hiding/showing items in extra step
 [website_sale_force_address_step](website_sale_force_address_step/) | 17.0.1.0.0 |  | Always show checkout address step, even if customer details exist
 [website_sale_force_autoinvoice](website_sale_force_autoinvoice/) | 17.0.1.1.0 |  | Forces autoinvoice on quotations created from website_sale
-[website_sale_force_login](website_sale_force_login/) | 17.0.1.1.0 |  | Force login before adding products to carts
+[website_sale_force_login](website_sale_force_login/) | 17.0.1.2.0 |  | Force login before adding products to carts
 [website_sale_hide_delivery_orders](website_sale_hide_delivery_orders/) | 17.0.1.0.0 |  | Hide Delivery Orders and Returns links from portal users
 [website_sale_invoice_transmit_method](website_sale_invoice_transmit_method/) | 17.0.1.0.0 |  | Adds account invoice transmit method to checkout
 [website_sale_invoicing_fee](website_sale_invoicing_fee/) | 17.0.1.0.0 |  | Adds Invoicing fee to Sale Order

--- a/website_sale_force_login/README.rst
+++ b/website_sale_force_login/README.rst
@@ -17,6 +17,15 @@ Usage
 =====
 \-
 
+Changelog
+=========
+
+17.0.1.2.0
+~~~~~~~~~~
+
+* t-cache attributes taken into use to mitigate issue where the result
+  of is_public_user() could be cached and produce wrong results when
+  e.g. reloading the page rapidly as a portal user.
 
 Credits
 =======

--- a/website_sale_force_login/__manifest__.py
+++ b/website_sale_force_login/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "eCommerce: Force login",
     "summary": "Force login before adding products to carts",
-    "version": "17.0.1.1.0",
+    "version": "17.0.1.2.0",
     "category": "Website",
     "website": "https://github.com/tawasta/e-commerce",
     "author": "Futural",

--- a/website_sale_force_login/views/website_product_template.xml
+++ b/website_sale_force_login/views/website_product_template.xml
@@ -6,6 +6,7 @@
             id="cart_login"
             class="d-inline-flex align-items-center mb-2 me-auto"
             t-if="website.is_public_user()"
+            t-nocache="Avoid caching public user checks"
         >
             <a
                 t-attf-href="/web/login?redirect=#{request.httprequest.url}"
@@ -23,7 +24,11 @@
                 href="#"
             ><i class="fa fa-lock me-2" /><small>Sign up</small></a>
         </div>
-        <div id="cart_login_guide" t-if="website.is_public_user()">
+        <div
+            id="cart_login_guide"
+            t-if="website.is_public_user()"
+            t-nocache="Avoid caching public user checks"
+        >
             <small><i
                     class="font-italic"
                 >Please login or sign up by registering your email address to continue</i></small>


### PR DESCRIPTION
- previously the check could give a wrong result when e.g. portal user reloaded the page rapidly multiple times