### PR TITLE
[FIX] prepopulate address form value from company registry, not vat, …

### DIFF
--- a/website_sale_company_registry/README.rst
+++ b/website_sale_company_registry/README.rst
@@ -24,6 +24,10 @@ Usage
 
 Known issues / Roadmap
 ======================
+* The suggested prefill value needs work when used in cases where customers 
+  register accounts before ordering, and both Finnish and non-Finnish 
+  countries are expected (the former should get a prefill
+  with Y-tunnus, the latter with VAT).
 * Some compatibility issues with other website_sale_* modules, e.g.
   installing company slider would make the VAT field mandatory.
 

--- a/website_sale_company_registry/views/website_sale_checkout.xml
+++ b/website_sale_company_registry/views/website_sale_checkout.xml
@@ -1,11 +1,25 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <!-- Re-label the VAT field on the address form -->
+
     <template id="address" inherit_id="website_sale.address" priority="101">
+        <!-- Re-label the VAT field on the address form -->
         <xpath expr="//label[@for='vat']" position="replace">
             <label for="vat" class="col-form-label">Company Registry / VAT Code</label>
         </xpath>
+
+        <!-- Prefill the field with company registry -->
+        <!--
+        Note: for use cases where both finnish AND nonfinnish countries are used, this needs further work.
+        For nonfinnish countries the VAT field value should be prepopulated
+        -->
+        <xpath expr="//input[@name='vat']" position="attributes">
+            <attribute
+                name="t-att-value"
+            >'company_registry' in checkout and checkout['company_registry']</attribute>
+        </xpath>
+
+
     </template>
 
 </odoo>


### PR DESCRIPTION
…preventing validation failure

- note: this is not a perfect fix and will need further tweaks for situations where finnish and nonfinnish partner countries are used